### PR TITLE
Bugfix: ArgumentException with the field display name

### DIFF
--- a/SPMin/SPMinEventReceiver/SPMinEventReceiver.cs
+++ b/SPMin/SPMinEventReceiver/SPMinEventReceiver.cs
@@ -103,7 +103,7 @@ namespace SPMin.SPMinEventReceiver
             var fileNameParser = new FileNameParser(path);
 
             minifiedFile.CheckIn("", SPCheckinType.MajorCheckIn);
-            minifiedFile.Item["Name"] = fileNameParser.GenerateMinifiedVersionFileName(hash);
+            minifiedFile.Item[SPBuiltInFieldId.FileLeafRef] = fileNameParser.GenerateMinifiedVersionFileName(hash);
             minifiedFile.Item.SystemUpdate();
 
             var fileHashDictionary = new FileHashDictionary(properties.ListItem.Web.Site);


### PR DESCRIPTION
ArgumentException with the field display name when site was created in a language different from English. The file was being created without the hash.
